### PR TITLE
fix: prefix release drafts with 'v'

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,8 +4,8 @@
 # 'minor' or 'patch' to determine which number in the version to increment.
 # You may need to add these labels yourself.
 # See https://github.com/release-drafter/release-drafter
-name-template: '$RESOLVED_VERSION'
-tag-template: '$RESOLVED_VERSION'
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
 change-template: '- $TITLE by @$AUTHOR (#$NUMBER)'
 no-changes-template: '- No changes'
 categories:


### PR DESCRIPTION
<!--
Please read the contributing guide before raising a pull request.
https://github.com/octokit/Octokit.Webhooks/blob/main/CONTRIBUTING.md
-->
